### PR TITLE
Adds suport for tvOS specific asset catalogs

### DIFF
--- a/Asset Catalog Tinkerer/CUICatalog.h
+++ b/Asset Catalog Tinkerer/CUICatalog.h
@@ -27,14 +27,41 @@
 
 @end
 
+@class CUIThemeRendition, CUIRenditionKey;
+
+
+@interface CUINamedLookup : NSObject
+
+@property(copy, nonatomic) NSString *name;
+@property(readonly, nonatomic) BOOL representsOnDemandContent;
+
+- (void)setRepresentsOnDemandContent:(BOOL)onDemand;
+- (id)renditionKey;
+- (NSString *)renditionName;
+- (id)initWithName:(NSString *)name usingRenditionKey:(NSString *)key fromTheme:(unsigned long long)theme;
+
+@end
+
+
+@interface CUINamedLayerStack : CUINamedLookup
+
+@property(retain, nonatomic) NSArray *layers;
+@property(readonly, nonatomic) struct CGImage *radiosityImage;
+@property(readonly, nonatomic) struct CGImage *flattenedImage;
+@property(readonly, nonatomic) struct CGSize size;
+
+@end
+
+
 @interface CUICatalog : NSObject
+
+@property (nonatomic, readonly) NSArray *allImageNames;
 
 + (instancetype)systemUICatalog;
 + (instancetype)defaultUICatalog;
 
 - (instancetype)initWithURL:(NSURL *)url error:(NSError **)outError;
-
-@property (nonatomic, readonly) NSArray *allImageNames;
+- (CUINamedLayerStack *)layerStackWithName:(NSString *)name;
 - (NSArray *)imagesWithName:(NSString *)name;
 
 @end

--- a/Asset Catalog Tinkerer/Window Controllers/ACTMainWC.m
+++ b/Asset Catalog Tinkerer/Window Controllers/ACTMainWC.m
@@ -105,22 +105,42 @@
             @autoreleasepool {
                 if (namedImage == nil) continue;
                 
-                NSString *filename;
-                if (namedImage.scale > 1.0) {
-                    filename = [NSString stringWithFormat:@"%@@%.0fx.png", namedImage.name, namedImage.scale];
+                NSData *pngData;
+                 NSString *filename;
+                if ([namedImage isKindOfClass:[CUINamedLayerStack class]]) {
+                    CUINamedLayerStack *namedLayerStack = (CUINamedLayerStack *)namedImage;
+                    if (namedLayerStack.flattenedImage == nil) {
+                        continue;
+                    }
+                    
+                    filename = namedLayerStack.renditionName;
+                    
+                    NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithCGImage:namedLayerStack.flattenedImage];
+                    imageRep.size = namedImage.size;
+                    
+                    pngData = [imageRep representationUsingType:NSPNGFileType properties:@{NSImageInterlaced:@(NO)}];
+                    if (!pngData.length) {
+                        NSLog(@"Unable to get PNG data from image named %@", namedImage.name);
+                        continue;
+                    }
+                    
                 } else {
-                    filename = [NSString stringWithFormat:@"%@.png", namedImage.name];
+                   
+                    if (namedImage.scale > 1.0) {
+                        filename = [NSString stringWithFormat:@"%@@%.0fx.png", namedImage.name, namedImage.scale];
+                    } else {
+                        filename = [NSString stringWithFormat:@"%@.png", namedImage.name];
+                    }
+                    
+                    NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithCGImage:namedImage.image];
+                    imageRep.size = namedImage.size;
+                    
+                    pngData = [imageRep representationUsingType:NSPNGFileType properties:@{NSImageInterlaced:@(NO)}];
+                    if (!pngData.length) {
+                        NSLog(@"Unable to get PNG data from image named %@", namedImage.name);
+                        continue;
+                    }
                 }
-                
-                NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithCGImage:namedImage.image];
-                imageRep.size = namedImage.size;
-                
-                NSData *pngData = [imageRep representationUsingType:NSPNGFileType properties:@{NSImageInterlaced:@(NO)}];
-                if (!pngData.length) {
-                    NSLog(@"Unable to get PNG data from image named %@", namedImage.name);
-                    continue;
-                }
-                
                 [self.images addObject:@{
                                          @"name" : namedImage.name,
                                          @"image" : [[NSImage alloc] initWithData:pngData],


### PR DESCRIPTION
When testing this with an Asset.car from a tvOS app a crash happened. So here's the extension of the CoreUI headers and a fix.
