### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An app that lets you open `.car` files and browse/extract their images, or previ
 
 [⬇ Download Latest Release](https://github.com/insidegui/AssetCatalogTinkerer/raw/master/releases/AssetCatalogTinkerer_latest.zip)
 
-You can also install it using [Homebrew Cask](https://caskroom.github.io), simply `brew cask install asset-catalog-tinkerer`!
+You can also install it using [Homebrew Cask](https://caskroom.github.io), simply `brew install --cask asset-catalog-tinkerer`!
 
 ![screenshot](https://raw.github.com/insidegui/AssetCatalogTinkerer/master/screenshot.png)
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524