### PR TITLE
Add symbols export to SVG

### DIFF
--- a/ACS/Private Headers/CoreSVG.h
+++ b/ACS/Private Headers/CoreSVG.h
@@ -1,0 +1,14 @@
+//
+
+#ifndef CoreSVG_h
+#define CoreSVG_h
+
+struct CGSVGDocument;
+
+typedef struct CGSVGDocument *CGSVGDocumentRef;
+
+int CGSVGDocumentWriteToURL(CGSVGDocumentRef, CFURLRef, CFDictionaryRef);
+int CGSVGDocumentWriteToData(CGSVGDocumentRef, CFDataRef, CFDictionaryRef);
+void CGContextDrawSVGDocument(CGContextRef, CGSVGDocumentRef);
+CGSize CGSVGDocumentGetCanvasSize(CGSVGDocumentRef);
+#endif /* CoreSVG_h */

--- a/ACS/Private Headers/CoreSVG.h
+++ b/ACS/Private Headers/CoreSVG.h
@@ -7,8 +7,7 @@ struct CGSVGDocument;
 
 typedef struct CGSVGDocument *CGSVGDocumentRef;
 
-int CGSVGDocumentWriteToURL(CGSVGDocumentRef, CFURLRef, CFDictionaryRef);
-int CGSVGDocumentWriteToData(CGSVGDocumentRef, CFDataRef, CFDictionaryRef);
-void CGContextDrawSVGDocument(CGContextRef, CGSVGDocumentRef);
-CGSize CGSVGDocumentGetCanvasSize(CGSVGDocumentRef);
+int CGSVGDocumentWriteToData(CGSVGDocumentRef, CFDataRef, CFDictionaryRef) __attribute__((weak_import));;
+void CGContextDrawSVGDocument(CGContextRef, CGSVGDocumentRef) __attribute__((weak_import));;
+CGSize CGSVGDocumentGetCanvasSize(CGSVGDocumentRef) __attribute__((weak_import));;
 #endif /* CoreSVG_h */

--- a/ACS/Private Headers/CoreUI.h
+++ b/ACS/Private Headers/CoreUI.h
@@ -7,6 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import "CoreSVG.h"
 
 @interface CUINamedData : NSObject
 
@@ -73,6 +74,8 @@ struct _renditionkeytoken {
 @property (readonly) long long themeSize;
 @property (readonly) long long themeElement;
 @property (readonly) long long themePart;
+@property (readonly) long long themeGlyphWeight;
+@property (readonly) long long themeGlyphSize;
 
 @end
 
@@ -82,6 +85,9 @@ struct _renditionkeytoken {
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSData *data;
 @property (nonatomic, readonly) CGImageRef unslicedImage;
+@property (nonatomic, readonly) BOOL isVectorBased;
+@property (nonatomic, readonly) struct CGSVGDocument *svgDocument;
+@property (nonatomic, readonly) long long vectorGlyphRenderingMode;
 
 @end
 
@@ -132,3 +138,32 @@ struct _renditionkeytoken {
 - (CUIStructuredThemeStore *)_themeStore;
 
 @end
+
+typedef NS_ENUM(NSInteger, UIImageSymbolScale) {
+    UIImageSymbolScaleDefault = -1,      // use the system default size
+    UIImageSymbolScaleUnspecified = 0,   // allow the system to pick a size based on the context
+    UIImageSymbolScaleSmall = 1,
+    UIImageSymbolScaleMedium,
+    UIImageSymbolScaleLarge,
+};
+
+typedef NS_ENUM(NSInteger, UIImageSymbolWeight) {
+    UIImageSymbolWeightUnspecified = 0,
+    UIImageSymbolWeightUltraLight = 1,
+    UIImageSymbolWeightThin,
+    UIImageSymbolWeightLight,
+    UIImageSymbolWeightRegular,
+    UIImageSymbolWeightMedium,
+    UIImageSymbolWeightSemibold,
+    UIImageSymbolWeightBold,
+    UIImageSymbolWeightHeavy,
+    UIImageSymbolWeightBlack
+};
+
+// This is a made up enum
+typedef NS_ENUM(NSInteger, UIImageSymbolRenderingMode) {
+    UIImageSymbolRenderingModeAutomatic,
+    UIImageSymbolRenderingModeTemplate,
+    UIImageSymbolRenderingModeMulticolor,
+    UIImageSymbolRenderingModeHierarchical,
+};

--- a/ACS/Source/AssetCatalogReader.h
+++ b/ACS/Source/AssetCatalogReader.h
@@ -17,7 +17,7 @@ extern NSString *__nonnull const kACSThumbnailKey;
 /// An NSString with the suggested filename for the asset
 extern NSString *__nonnull const kACSFilenameKey;
 /// An NSData containing PNG image data for the asset
-extern NSString *__nonnull const kACSPNGDataKey;
+extern NSString *__nonnull const kACSContentsDataKey;
 /// An NSBitmapImageRep containing a bitmap representation of the asset
 extern NSString *__nonnull const kACSImageRepKey;
 

--- a/ACS/Source/AssetCatalogReader.m
+++ b/ACS/Source/AssetCatalogReader.m
@@ -258,8 +258,8 @@ NSString * const kAssetCatalogReaderErrorDomain = @"br.com.guilhermerambo.AssetC
             if ([self catalogHasRetinaContent] && weakSelf.resourceConstrained && rendition.scale < 2) {
                 return;
             }
-                
-            const BOOL isSVG = rendition.isVectorBased && rendition.svgDocument;
+            const BOOL coreSVGPresent = CGSVGDocumentGetCanvasSize != NULL && CGContextDrawSVGDocument != NULL && CGSVGDocumentWriteToData != NULL;
+            const BOOL isSVG = coreSVGPresent && rendition.isVectorBased && rendition.svgDocument;
             if (isSVG) {
                 NSCustomImageRep *imageRep = [[NSCustomImageRep alloc] initWithSize:CGSVGDocumentGetCanvasSize(rendition.svgDocument) flipped:YES drawingHandler:^BOOL(NSRect dstRect) {
                     CGContextRef context = NSGraphicsContext.currentContext.CGContext;

--- a/Asset Catalog Tinkerer.xcodeproj/project.pbxproj
+++ b/Asset Catalog Tinkerer.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		32A9FFF225D5CCEF00921AD7 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 32A9FFF125D5CCEF00921AD7 /* Sparkle */; };
+		5CCAA8B92BBEC7C200AAC600 /* CoreSVG.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CCAA8B82BBEC7C200AAC600 /* CoreSVG.framework */; };
 		DD8118B31E5DC4DD00426746 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8118B21E5DC4DD00426746 /* Preferences.swift */; };
 		DDA691CB1CFA02CA00583328 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA691CA1CFA02CA00583328 /* MainWindowController.swift */; };
 		DDADF2AF2026678C003CB15D /* NSImage+BrightnessDetection.m in Sources */ = {isa = PBXBuildFile; fileRef = DDADF2AE2026678C003CB15D /* NSImage+BrightnessDetection.m */; };
@@ -92,6 +93,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5CCAA8B72BBEC56F00AAC600 /* CoreSVG.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreSVG.h; sourceTree = "<group>"; };
+		5CCAA8B82BBEC7C200AAC600 /* CoreSVG.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSVG.framework; path = ../../../../System/Library/PrivateFrameworks/CoreSVG.framework; sourceTree = "<group>"; };
 		DD8118B21E5DC4DD00426746 /* Preferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		DDA23B2322CC0BA500600574 /* Asset Catalog Tinkerer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Asset Catalog Tinkerer.entitlements"; sourceTree = "<group>"; };
 		DDA691CA1CFA02CA00583328 /* MainWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
@@ -138,6 +141,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CCAA8B92BBEC7C200AAC600 /* CoreSVG.framework in Frameworks */,
 				DDAF8AEA1E1B11DB00A8A235 /* CoreUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -207,6 +211,7 @@
 			children = (
 				DDAF8AE01E1B119A00A8A235 /* CoreUI+TV.h */,
 				DDAF8AE11E1B119A00A8A235 /* CoreUI.h */,
+				5CCAA8B72BBEC56F00AAC600 /* CoreSVG.h */,
 			);
 			path = "Private Headers";
 			sourceTree = "<group>";
@@ -214,6 +219,7 @@
 		DDAF8AE81E1B11DB00A8A235 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5CCAA8B82BBEC7C200AAC600 /* CoreSVG.framework */,
 				F450A900275A46E700C5DB9B /* UniformTypeIdentifiers.framework */,
 				DDAF8AEB1E1B11DF00A8A235 /* ProKit.framework */,
 				DDAF8AE91E1B11DB00A8A235 /* CoreUI.framework */,

--- a/Asset Catalog Tinkerer/ImagesCollectionViewDataProvider.swift
+++ b/Asset Catalog Tinkerer/ImagesCollectionViewDataProvider.swift
@@ -112,7 +112,7 @@ class ImagesCollectionViewDataProvider: NSObject, NSCollectionViewDataSource, NS
         let image = filteredImages[indexPath.item]
 
         guard let filename = image["filename"] as? String else { return nil }
-        guard let data = image["png"] as? Data else { return nil }
+        guard let data = image["data"] as? Data else { return nil }
         
         let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent(filename)
@@ -149,7 +149,7 @@ extension ImagesCollectionViewDataProvider: NSFilePromiseProviderDelegate {
             return
         }
         
-        guard let data = image["png"] as? Data else {
+        guard let data = image["data"] as? Data else {
             completionHandler(nil)
             return
         }

--- a/Asset Catalog Tinkerer/ImagesViewController.swift
+++ b/Asset Catalog Tinkerer/ImagesViewController.swift
@@ -283,11 +283,9 @@ class ImagesViewController: NSViewController, NSMenuItemValidation {
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.canCreateDirectories = true
-        
         panel.beginSheetModal(for: view.window!) { result in
             guard result == .OK else { return }
             guard panel.url != nil else { return }
-            
             self.exportImages(imagesToExport, toDirectoryAt: panel.url!)
         }
     }
@@ -303,11 +301,11 @@ class ImagesViewController: NSViewController, NSMenuItemValidation {
                 
                 pathComponents.append(filename)
                 
-                guard let pngData = image["png"] as? Data else { return }
+                guard let contents = image["data"] as? Data else { return }
                 
                 let path = self.nextAvailablePath(filePath: NSString.path(withComponents: pathComponents) as String)
                 do {
-                    try pngData.write(to: URL(fileURLWithPath: path), options: .atomic)
+                    try contents.write(to: URL(fileURLWithPath: path), options: .atomic)
                 } catch {
                     NSLog("ERROR: Unable to write \(filename) to \(path); \(error)")
                 }

--- a/AssetCatalog/QuickLookHelper.m
+++ b/AssetCatalog/QuickLookHelper.m
@@ -126,7 +126,7 @@
     CGFloat lastRowHeight = 0;
     
     for (NSDictionary *asset in self.reader.images) {
-        NSBitmapImageRep *rep = asset[kACSImageRepKey];
+        NSImageRep *rep = asset[kACSImageRepKey];
         
         NSSize size = [self fitSize:rep.size inSize:referenceSize];
         
@@ -235,7 +235,7 @@
     NSMutableArray <NSNumber *> *heights = [[NSMutableArray alloc] initWithCapacity:self.reader.images.count];
     
     [self.reader.images enumerateObjectsUsingBlock:^(NSDictionary* asset, NSUInteger idx, BOOL *stop) {
-        NSBitmapImageRep *rep = asset[kACSImageRepKey];
+        NSImageRep *rep = asset[kACSImageRepKey];
         [widths addObject:@(rep.size.width)];
         [heights addObject:@(rep.size.height)];
     }];


### PR DESCRIPTION
This is a very rudimentary support of SF symbols export to SVG
From my testing it appears that:
* As long as SVG exported by SF symbols includes layers [mentioned in the documentation](https://developer.apple.com/documentation/uikit/uiimage/creating_custom_symbol_images_for_your_app) it is recognized by Xcode as a custom SF Symbol and it will be exported as SVG
* If you import a regular SVG it will be converted to a bitmap asset with @1x @2x @3x scales

Because of this checking for SVG document on rendition is enough to assume this is an SF symbol
This allows to infer symbol weight, size and rendering mode and generate an appropriate file name
Sadly each symbol weight is a separate rendition. In the future we can collate symbols by names and compose SVG following documentation referenced above

For now this should do for enthusiasts eager to export to SVG